### PR TITLE
Ledger: adding missing Alonzo.validateTooManyCollateralInputs rule

### DIFF
--- a/src/ledger/block-validation.md
+++ b/src/ledger/block-validation.md
@@ -185,6 +185,7 @@ EUC[EraRule UTXOW Conway]
                 utxoTransition --> validateWrongNetworkInTxBody(Alonzo.validateWrongNetworkInTxBody)
                 utxoTransition --> validateMaxTxSizeUTxO(Shelley.vallidateMaxTxSizeUTxO)
                 utxoTransition --> validateExUnitsTooBigUTxO(Alonzo.validateExUnitsTooBigUTxO)
+                utxoTransition --> validateTooManyCollateralInputs(Alonzo.validateTooManyCollateralInputs)
                 utxoTransition --> EUTXOSC[EraRule UTXOS Conway]
                     EUTXOSC --> utxosTransition
                 utxosTransition --> isValidTxL{isValidTxL}
@@ -340,6 +341,7 @@ flowchart LR
                                         utxoTransition --> validateWrongNetworkInTxBody(Alonzo.validateWrongNetworkInTxBody)
                                         utxoTransition --> validateMaxTxSizeUTxO(Shelley.vallidateMaxTxSizeUTxO)
                                         utxoTransition --> validateExUnitsTooBigUTxO(Alonzo.validateExUnitsTooBigUTxO)
+                                        utxoTransition --> validateTooManyCollateralInputs(Alonzo.validateTooManyCollateralInputs)
                                         utxoTransition --> EUTXOSC[EraRule UTXOS Conway]
                                             EUTXOSC --> utxosTransition
                                                 utxosTransition --> isValidTxL{isValidTxL}


### PR DESCRIPTION
It seems that Ledger EraRule UTXOW and Full Diagrams are missing Alonzo.validateTooManyCollateralInputs rule.