### PR TITLE
Add yHSJ as code owner for ledger/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 src/client/ @ch1bo
 src/codecs/ @jasegredo
 
-src/ledger/ @nc6
+src/ledger/ @nc6 @yHSJ
 
 src/consensus/ @jasegredo
 src/mempool/ @jasegredo


### PR DESCRIPTION
@yHSJ There are not many strings attached to this. The contribution guidelines do not require specific approvals right now: https://github.com/cardano-scaling/cardano-blueprint/blob/9ca208f9dcde6aca02a913750b32a64428c5253e/CONTRIBUTING.md#write-blueprints but I thought about mentioning code owners once introduced (in also a non-enforcing capacity for now) as stated in https://github.com/cardano-scaling/cardano-blueprint/issues/23