### PR TITLE
leios-prototype: define `point` as a nested array, matching the impl

### DIFF
--- a/src/network/node-to-node/leios-fetch/messages.cddl
+++ b/src/network/node-to-node/leios-fetch/messages.cddl
@@ -25,7 +25,7 @@ msgLeiosBlockTxs               = [3, point, bitmaps, tx_list]
 ; msgLeiosLastBlockAndTxsInRange = [8, endorser_block, tx_list]
 msgClientDone                  = [9]
 
-point = (slot, eb_hash)
+point = [slot, eb_hash]
 slot = base.slotno
 eb_hash = base.hash
 

--- a/src/network/node-to-node/leios-notify/messages.cddl
+++ b/src/network/node-to-node/leios-notify/messages.cddl
@@ -14,7 +14,7 @@ msgLeiosVotes                   = [4, [1* vote]]
 msgClientDone                   = [5]
 
 announcement = any ; TODO
-point = (slot, eb_hash)
+point = [slot, eb_hash]
 eb_size = base.word32 ; TODO should not be needed, because announcement
 slot = base.slotno
 eb_hash = base.hash


### PR DESCRIPTION
On the `leios-prototype` branch, `point` is defined as a CBOR group:

```cddl
point = (slot, eb_hash)
```

Parentheses denote a group, whose members splice inline into the enclosing array. Read literally, that makes:

```cddl
msgLeiosBlockRequest    = [0, point]            =>  [0, slot, eb_hash]            ; 3 flat elements
msgLeiosBlockTxsRequest = [2, point, bitmaps]   =>  [2, slot, eb_hash, bitmaps]   ; 4 flat elements
msgLeiosBlockOffer      = [2, point, eb_size]   =>  [2, slot, eb_hash, eb_size]   ; 4 flat elements
```

i.e. `slot` and `eb_hash` as top-level array elements.

The reference implementation, however, encodes `point` as a nested two-element array `[slot, eb_hash]`, so the actual messages are `[0, [slot, eb_hash]]`, `[2, [slot, eb_hash], bitmaps]`, etc. Confirmed on the wire against the `leios-node.play.dev.cardano.org` prototype relay, which both emits `point` as a nested array in LeiosNotify block offers and accepts it that way on LeiosFetch requests; encoding it as the inlined group instead fails to interoperate.

This PR brings the CDDL into line with the implementation by defining `point` as a nested array in both `leios-fetch/messages.cddl` and `leios-notify/messages.cddl`.

Closes #68.